### PR TITLE
Add support for 2023.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,7 @@
 ## [1.10.1]
 ### Added
 - Added compatibility for `2022.3.2`
+-
+## [1.10.2]
+### Added
+- Added compatibility for `2023.1`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Kediatr Helper
 =======================
 
 [![CodeFactor](https://www.codefactor.io/repository/github/bilal-kilic/kediatr-helper/badge)](https://www.codefactor.io/repository/github/bilal-kilic/kediatr-helper)
-[![JetBrains Plugins](https://img.shields.io/badge/1.10.1-kediatr--helper-brightgreen)](https://plugins.jetbrains.com/plugin/16017-kediatr-helper)
+[![JetBrains Plugins](https://img.shields.io/badge/1.10.2-kediatr--helper-brightgreen)](https://plugins.jetbrains.com/plugin/16017-kediatr-helper)
 
 
 <!-- Plugin description -->

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup=org.github.bilalkilic.kediatrhelper
 pluginName_=Kediatr Helper
 pluginVersion=1.10.2
 pluginSinceBuild=203
-pluginUntilBuild=231.*
+pluginUntilBuild=
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=org.github.bilalkilic.kediatrhelper
 pluginName_=Kediatr Helper
-pluginVersion=1.10.1
+pluginVersion=1.10.2
 pluginSinceBuild=203
-pluginUntilBuild=223.*
+pluginUntilBuild=231.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3.1


### PR DESCRIPTION
As mentioned [here](https://github.com/JetBrains/intellij-platform-plugin-template/issues/325#issuecomment-1347954027) we can disable pluginUntilBuild thus we won't need to release a new version for every JetBrains upgrade.